### PR TITLE
Use serviceName config parameter to populate service name. 

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -56,6 +56,7 @@ An example configuration file might look like below.  *Note:* The comments would
             {
                 "input": "mxd/my_map_document.mxd", // Required
                 "output": "output/", // Optional, defaults to "output/"
+                "serviceName": "MyMapDocument", // Optional, defaults to MXD filename, "my_map_document" here
                 "serverType": "ARCGIS_SERVER", // Optional, defaults to "ARCGIS_SERVER"
                 "copyDataToServer": "False", // Optional, defaults to False
                 "folderName": "AutomationTests", // Optional, defaults to ""

--- a/readme.md
+++ b/readme.md
@@ -65,11 +65,11 @@ An example configuration file might look like below.  *Note:* The comments would
                     {
                         "old": {
                             "path": "c:/path/to/integration/connectionFile.sde", // Required if workspaces is defined
-                            "type": "SDE_WORKSPACE" // Optional, defaults to SDE_WORKSPACE
+                            "type": "SDE_WORKSPACE" // Optional, defaults to SDE_WORKSPACE, for file geodatabase, use "FILEGDB_WORKSPACE"
                         },
                         "new": {
                             "path": "c:/path/to/production/connectionFile.sde", // Required if workspaces is defined
-                            "type": "SDE_WORKSPACE" // Optional, defaults to SDE_WORKSPACE
+                            "type": "SDE_WORKSPACE" // Optional, defaults to SDE_WORKSPACE, for file geodatabase, use "FILEGDB_WORKSPACE"
                           }
                     }
                 ],
@@ -193,9 +193,11 @@ the script will replace each `old` workspace path (i.e., path to a connection fi
 
 A few notes and caveats:
 
-- Ideally, database connections will be via SDE, and use a connection file.  Sourcing from a File Geodatabase is also supported; note that the FGDB will likely not be checked into version control.
+- Ideally, database connections will be via SDE, and use a connection file.  Sourcing from a File Geodatabase is also supported; 
+  note that the FGDB will likely not be checked into version control. For file geodatabase, `"type": "FILEGDB_WORKSPACE"`
 - If the FGDB sits on a share, consider using a UNC path rather than a drive letter, unless you are **sure** that the drive will always be mapped.
 - For network shares (i.e., sourcing a FGDB), you *must* use JSON-escaped backslashes in the config (i.e., `\\`).  The `inputs` parameter should *not* add escapes (i.e., use `\`).
+- It is possible to source from both an enterprise geodatabase(s) and file geodatabases(s) in the same MXD.
 
 ## TODO
 - Add support for Image Services, GP Services, etc.

--- a/slap/publisher.py
+++ b/slap/publisher.py
@@ -58,7 +58,7 @@ class Publisher:
         arcpy.CreateGPSDDraft(
             result=result,
             out_sddraft=sddraft,
-            service_name=filename,
+            service_name=config_entry["serviceName"] if "serviceName" in config_entry else filename,
             server_type=config_entry["serverType"] if "serverType" in config_entry else 'ARCGIS_SERVER',
             connection_file_path=self.connection_file_path,
             copy_data_to_server=config_entry["copyDataToServer"] if "copyDataToServer" in config_entry else False,
@@ -87,7 +87,7 @@ class Publisher:
         arcpy.mapping.CreateMapSDDraft(
             map_document=mxd,
             out_sddraft=sddraft,
-            service_name=filename,
+            service_name=config_entry["serviceName"] if "serviceName" in config_entry else filename,
             server_type=config_entry["serverType"] if "serverType" in config_entry else 'ARCGIS_SERVER',
             connection_file_path=self.connection_file_path,
             copy_data_to_server=config_entry["copyDataToServer"] if "copyDataToServer" in config_entry else False,
@@ -102,7 +102,7 @@ class Publisher:
         arcpy.CreateImageSDDraft(
             raster_or_mosaic_layer=config_entry["input"],
             out_sddraft=sddraft,
-            service_name=filename,
+            service_name=config_entry["serviceName"] if "serviceName" in config_entry else filename,
             connection_file_path=self.connection_file_path,
             server_type=config_entry["serverType"] if "serverType" in config_entry else 'ARCGIS_SERVER',
             copy_data_to_server=config_entry["copyDataToServer"] if "copyDataToServer" in config_entry else False,
@@ -185,7 +185,7 @@ class Publisher:
 
     def publish_service(self, service_type, config_entry):
         filename = os.path.splitext(os.path.split(config_entry["input"])[1])[0]
-        config_entry['json']['serviceName'] = filename
+        config_entry['json']['serviceName'] = config_entry["serviceName"] if "serviceName" in config_entry else filename
 
         output_directory = self.get_output_directory(config_entry)
         if not os.path.exists(output_directory):


### PR DESCRIPTION
This allows per-service optional service name to set in config. If not present for a service in config, service name defaults to MXD filename.